### PR TITLE
Let Paranoia take ownership of the Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ let mut paranoia = drive.paranoia();
 let mut writer = hound::WavWriter::create(
     "/tmp/example.wav",
     hound::WavSpec {
-        channels: drive.track_channels(1).unwrap_or(2).into(),
+        channels: paranoia.drive().track_channels(1).unwrap_or(2).into(),
         sample_rate: 44100,
         bits_per_sample: 16,
         sample_format: hound::SampleFormat::Int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! let mut writer = hound::WavWriter::create(
 //!     "/tmp/example.wav",
 //!     hound::WavSpec {
-//!         channels: drive.track_channels(1).unwrap_or(2).into(),
+//!         channels: paranoia.drive().track_channels(1).unwrap_or(2).into(),
 //!         sample_rate: 44100,
 //!         bits_per_sample: 16,
 //!         sample_format: hound::SampleFormat::Int,
@@ -125,8 +125,7 @@ impl Drive {
 
 impl Drive {
     /// Get a [`Paranoia`] instance for reading audio data.
-    #[allow(clippy::needless_lifetimes)]
-    pub fn paranoia<'drive>(&'drive self) -> Paranoia<'drive> {
+    pub fn paranoia(self) -> Paranoia {
         Paranoia::new(self)
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,64 +5,66 @@ use crate::{Drive, Error, Result};
 
 /// Allows reading audio data from a CD.
 #[derive(Debug)]
-pub struct Paranoia<'drive> {
+pub struct Paranoia {
     ptr: *mut crate::ffi::cdrom_paranoia,
-    drive: &'drive Drive,
+    drive: Drive,
 }
 
-impl<'drive> Drop for Paranoia<'drive> {
+impl Drop for Paranoia {
     fn drop(&mut self) {
         unsafe { crate::ffi::paranoia_free(self.ptr) };
     }
 }
 
-impl<'drive> Paranoia<'drive> {
-    pub(crate) fn new(drive: &'drive Drive) -> Self {
+impl Paranoia {
+    pub(crate) fn new(drive: Drive) -> Self {
         let ptr = unsafe { crate::ffi::paranoia_init(drive.as_ptr()) };
         assert!(!ptr.is_null(), "paranoia_init should be infallible");
         Self { ptr, drive }
     }
 }
 
-impl<'drive, 'paranoia> Paranoia<'drive>
-where
-    'drive: 'paranoia,
-{
+impl From<Drive> for Paranoia {
+    fn from(drive: Drive) -> Self {
+        Self::new(drive)
+    }
+}
+
+impl Paranoia {
+    /// Get a reference to the underlying [`Drive`].
+    pub fn drive(&self) -> &Drive {
+        &self.drive
+    }
+}
+
+impl Paranoia {
     /// Read audio data from a track.
-    pub fn read_track(&'paranoia mut self, track: u8) -> Result<DiscReader<'drive, 'paranoia>> {
+    pub fn read_track(&mut self, track: u8) -> Result<DiscReader<'_>> {
         self.read_track_limited(track, 20)
     }
     /// Read audio data from a track with a custom retry count.
-    pub fn read_track_limited(
-        &'paranoia mut self,
-        track: u8,
-        max_retries: i32,
-    ) -> Result<DiscReader<'drive, 'paranoia>> {
+    pub fn read_track_limited(&mut self, track: u8, max_retries: i32) -> Result<DiscReader<'_>> {
         let first_lsn = self.drive.track_first_sector(track)?;
         let last_lsn = self.drive.track_last_sector(track)?;
 
         Ok(self.read_sectors_limited(first_lsn, last_lsn, max_retries))
     }
     /// Read a range of sectors.
-    pub fn read_sectors(
-        &'paranoia mut self,
-        first_lsn: u32,
-        last_lsn: u32,
-    ) -> DiscReader<'drive, 'paranoia> {
+    pub fn read_sectors(&mut self, first_lsn: u32, last_lsn: u32) -> DiscReader<'_> {
         self.read_sectors_limited(first_lsn, last_lsn, 20)
     }
     /// Read a range of sectors with a custom retry count.
     pub fn read_sectors_limited(
-        &'paranoia mut self,
+        &mut self,
         first_lsn: u32,
         last_lsn: u32,
         max_retries: i32,
-    ) -> DiscReader<'drive, 'paranoia> {
+    ) -> DiscReader<'_> {
         DiscReader::new(self, first_lsn, last_lsn, max_retries)
     }
 }
 
-impl<'drive> Paranoia<'drive> {
+impl Paranoia {
     pub fn as_ptr(&self) -> *mut crate::ffi::cdrom_paranoia {
         self.ptr
     }
@@ -75,22 +77,16 @@ impl<'drive> Paranoia<'drive> {
 /// which will clone the audio buffers. If you prefer to read the data
 /// without cloning, you can use the [`next_sector()`](DiscReader::next_sector) method.
 #[derive(Debug)]
-pub struct DiscReader<'drive, 'paranoia>
-where
-    'drive: 'paranoia,
-{
-    paranoia: &'paranoia mut Paranoia<'drive>,
+pub struct DiscReader<'paranoia> {
+    paranoia: &'paranoia mut Paranoia,
     last_lsn: u32,
     current_lsn: u32,
     max_retries: i32,
 }
 
-impl<'drive, 'paranoia> DiscReader<'drive, 'paranoia>
-where
-    'drive: 'paranoia,
-{
+impl<'paranoia> DiscReader<'paranoia> {
     pub(crate) fn new(
-        paranoia: &'paranoia mut Paranoia<'drive>,
+        paranoia: &'paranoia mut Paranoia,
         first_lsn: u32,
         last_lsn: u32,
         max_retries: i32,
@@ -104,7 +100,7 @@ where
     }
 }
 
-impl<'drive, 'paranoia> DiscReader<'drive, 'paranoia> {
+impl<'paranoia> DiscReader<'paranoia> {
     /// Read the next sector of audio data without cloning.
     pub fn next_sector(&mut self) -> Option<Result<&[i16]>> {
         if self.current_lsn == self.last_lsn {
@@ -126,7 +122,7 @@ impl<'drive, 'paranoia> DiscReader<'drive, 'paranoia> {
     }
 }
 
-impl<'drive, 'paranoia> Iterator for DiscReader<'drive, 'paranoia> {
+impl<'paranoia> Iterator for DiscReader<'paranoia> {
     type Item = Result<Vec<i16>>;
 
     /// Read the next sector of audio data.


### PR DESCRIPTION
CC @agausmann

solves

> it only takes a shared reference
to the Drive, so it is possible to create multiple Paranoia instances
with overlapping lifetimes, which may have the potential to cause problems
> ([source](https://lists.sr.ht/~agausmann/public-inbox/%3C6b0ca3fa-a829-50ca-0634-77869c87e299%40mailbox.org%3E#%3C2QKM8B8MT3M1W.28URSVTPE5BS8@reliant.gaussian.dev%3E))

This also reduces the explicit lifetime annotations, making the code easier to read.

