### PR TITLE
Capture messages and integrate with `tracing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,14 @@ cdparanoia3-sys = { version = "0.1.0", path = "cdparanoia3-sys", optional = true
 num-traits = "0.2.15"
 num_enum = "0.6.1"
 thiserror = "1.0.43"
+tracing = { version = "0.1.37", optional = true }
 
 [features]
 default = ["libcdio-paranoia"]
 libcdio-paranoia = ["dep:cdio-paranoia-sys"]
 cdparanoia-3 = ["dep:cdparanoia3-sys"]
+tracing = ["dep:tracing", "cdparanoia3-sys?/libc"]
 
 [dev-dependencies]
 hound = "3.5.0"
+tracing-subscriber = "0.3.17"

--- a/cdparanoia3-sys/Cargo.toml
+++ b/cdparanoia3-sys/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["cd", "cdrom", "audio-cd", "cdparanoia"]
 categories = ["external-ffi-bindings", "multimedia::audio"]
 
 [dependencies]
+libc = { version = "0.2.148", optional = true }
 
 [build-dependencies]
 bindgen = "0.66.1"

--- a/cdparanoia3-sys/src/lib.rs
+++ b/cdparanoia3-sys/src/lib.rs
@@ -8,3 +8,8 @@
 #![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+// cdparanoia-3 doesn't export a `cdda_free_messages()`,
+// so we re-export libc which provides `free()`
+#[cfg(feature = "libc")]
+pub use libc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,11 @@ compile_error!(
     "Either feature \"libcdio-paranoia\" or \"cdparanoia-3\" must be enabled for this crate."
 );
 
+#[cfg(feature = "tracing")]
+const MESSAGE_DEST: i32 = crate::ffi::CDDA_MESSAGE_LOGIT as i32;
+#[cfg(not(feature = "tracing"))]
+const MESSAGE_DEST: i32 = crate::ffi::CDDA_MESSAGE_PRINTIT as i32;
+
 mod error;
 mod read;
 
@@ -80,6 +85,7 @@ pub struct Drive {
 
 impl Drop for Drive {
     fn drop(&mut self) {
+        self.check_messages();
         unsafe { crate::ffi::cdda_close(self.ptr) };
     }
 }
@@ -87,37 +93,35 @@ impl Drop for Drive {
 impl Drive {
     /// Open a default CD-ROM drive with a CD-DA in it.
     pub fn find() -> Result<Self> {
-        let ptr = unsafe {
-            crate::ffi::cdda_find_a_cdrom(
-                crate::ffi::CDDA_MESSAGE_PRINTIT as i32,
-                std::ptr::null_mut(),
-            )
-        };
+        let ptr = unsafe { crate::ffi::cdda_find_a_cdrom(MESSAGE_DEST, std::ptr::null_mut()) };
         if ptr.is_null() {
             return Err(Error::CantOpenDrive);
         }
         let drive = Drive { ptr };
 
+        drive.check_messages();
+
         ParanoiaError::check_result(unsafe { crate::ffi::cdda_open(drive.as_ptr()) })?;
+
+        drive.check_messages();
 
         Ok(drive)
     }
     /// Open a specific CD-ROM drive with a CD-DA in it.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let path = CString::new(path.as_ref().as_os_str().as_bytes())?;
-        let ptr = unsafe {
-            crate::ffi::cdda_identify(
-                path.as_ptr(),
-                crate::ffi::CDDA_MESSAGE_PRINTIT as i32,
-                std::ptr::null_mut(),
-            )
-        };
+        let ptr =
+            unsafe { crate::ffi::cdda_identify(path.as_ptr(), MESSAGE_DEST, std::ptr::null_mut()) };
         if ptr.is_null() {
             return Err(Error::CantOpenDrive);
         }
         let drive = Drive { ptr };
 
+        drive.check_messages();
+
         ParanoiaError::check_result(unsafe { crate::ffi::cdda_open(drive.as_ptr()) })?;
+
+        drive.check_messages();
 
         Ok(drive)
     }
@@ -136,29 +140,30 @@ impl Drive {
     pub fn track_first_sector(&self, track: u8) -> Result<u32> {
         #[cfg(not(feature = "libcdio-paranoia"))]
         let track = track.into();
-        match ParanoiaError::check_result(unsafe {
+        let lsn = ParanoiaError::check_result(unsafe {
             crate::ffi::cdda_track_firstsector(self.as_ptr(), track)
-        }) {
-            Ok(lsn) => Ok(lsn as u32),
-            Err(e) => Err(e.into()),
-        }
+        })? as u32;
+        self.check_messages();
+        Ok(lsn)
     }
     /// Get the last logical sector number of a track.
     /// This is generally one less than the start of the next track.
     pub fn track_last_sector(&self, track: u8) -> Result<u32> {
         #[cfg(not(feature = "libcdio-paranoia"))]
         let track = track.into();
-        match ParanoiaError::check_result(unsafe {
+        let lsn = ParanoiaError::check_result(unsafe {
             crate::ffi::cdda_track_lastsector(self.as_ptr(), track)
-        }) {
-            Ok(lsn) => Ok(lsn as u32),
-            Err(e) => Err(e.into()),
-        }
+        })? as u32;
+        self.check_messages();
+        Ok(lsn)
     }
     /// Get the number of tracks on the CD.
     #[allow(clippy::let_and_return)]
     pub fn tracks(&self) -> u8 {
         let tracks = unsafe { crate::ffi::cdda_tracks(self.as_ptr()) };
+
+        self.check_messages();
+
         #[cfg(not(feature = "libcdio-paranoia"))]
         let tracks = tracks.try_into().unwrap();
         tracks
@@ -172,18 +177,18 @@ impl Drive {
         #[cfg(not(feature = "libcdio-paranoia"))]
         let lsn = lsn.into();
 
-        let track = unsafe { crate::ffi::cdda_sector_gettrack(self.as_ptr(), lsn) };
+        let track = ParanoiaError::check_result(unsafe {
+            crate::ffi::cdda_sector_gettrack(self.as_ptr(), lsn)
+        })?;
 
-        match ParanoiaError::check_result(track) {
-            Ok(track) => {
-                #[cfg(feature = "libcdio-paranoia")]
-                if track as u32 == crate::ffi::cdio_track_enums::CDIO_INVALID_TRACK {
-                    return Err(ParanoiaError::InvalidTrackNumber.into());
-                }
-                Ok(track.try_into().unwrap())
-            }
-            Err(e) => Err(e.into()),
+        self.check_messages();
+
+        #[cfg(feature = "libcdio-paranoia")]
+        if track as u32 == crate::ffi::cdio_track_enums::CDIO_INVALID_TRACK {
+            return Err(ParanoiaError::InvalidTrackNumber.into());
         }
+
+        Ok(track.try_into().unwrap())
     }
     /// Get the number of channels in a track.
     ///
@@ -192,21 +197,34 @@ impl Drive {
     pub fn track_channels(&self, track: u8) -> Option<u8> {
         #[cfg(not(feature = "libcdio-paranoia"))]
         let track = track.into();
-        unsafe { crate::ffi::cdda_track_channels(self.as_ptr(), track) }
+        let track_channels = unsafe { crate::ffi::cdda_track_channels(self.as_ptr(), track) }
             .try_into()
-            .ok()
+            .ok();
+
+        self.check_messages();
+
+        track_channels
     }
     /// Check if a track is an audio track.
     pub fn track_audio(&self, track: u8) -> bool {
         #[cfg(not(feature = "libcdio-paranoia"))]
         let track = track.into();
-        unsafe { crate::ffi::cdda_track_audiop(self.as_ptr(), track) == 1 }
+        let track_audio = unsafe { crate::ffi::cdda_track_audiop(self.as_ptr(), track) == 1 };
+
+        self.check_messages();
+
+        track_audio
     }
     /// Check if a track has copy permit set.
     pub fn track_copy_permitted(&self, track: u8) -> bool {
         #[cfg(not(feature = "libcdio-paranoia"))]
         let track = track.into();
-        unsafe { crate::ffi::cdda_track_copyp(self.as_ptr(), track) == 1 }
+        let track_copy_permitted =
+            unsafe { crate::ffi::cdda_track_copyp(self.as_ptr(), track) == 1 };
+
+        self.check_messages();
+
+        track_copy_permitted
     }
     /// Check if a track has linear preemphasis set.
     ///
@@ -214,25 +232,32 @@ impl Drive {
     pub fn track_linear_preemphasis(&self, track: u8) -> bool {
         #[cfg(not(feature = "libcdio-paranoia"))]
         let track = track.into();
-        unsafe { crate::ffi::cdda_track_preemp(self.as_ptr(), track) == 1 }
+        let track_linear_preemphasis =
+            unsafe { crate::ffi::cdda_track_preemp(self.as_ptr(), track) == 1 };
+
+        self.check_messages();
+
+        track_linear_preemphasis
     }
     /// Get the first logical sector number of the first audio track.
     pub fn disc_first_sector(&self) -> Result<u32> {
-        match ParanoiaError::check_result(unsafe {
+        let lsn = ParanoiaError::check_result(unsafe {
             crate::ffi::cdda_disc_firstsector(self.as_ptr())
-        }) {
-            Ok(lsn) => Ok(lsn as u32),
-            Err(e) => Err(e.into()),
-        }
+        })? as u32;
+
+        self.check_messages();
+
+        Ok(lsn)
     }
     /// Get the last logical sector number of the last audio track.
     pub fn disc_last_sector(&self) -> Result<u32> {
-        match ParanoiaError::check_result(unsafe {
+        let lsn = ParanoiaError::check_result(unsafe {
             crate::ffi::cdda_disc_lastsector(self.as_ptr())
-        }) {
-            Ok(lsn) => Ok(lsn as u32),
-            Err(e) => Err(e.into()),
-        }
+        })? as u32;
+
+        self.check_messages();
+
+        Ok(lsn)
     }
 }
 
@@ -240,5 +265,40 @@ impl Drive {
     #[inline]
     pub fn as_ptr(&self) -> *mut crate::ffi::cdrom_drive {
         self.ptr
+    }
+    #[cfg(not(feature = "tracing"))]
+    pub(crate) fn check_messages(&self) {}
+    #[cfg(feature = "tracing")]
+    pub(crate) fn check_messages(&self) {
+        use std::ffi::CStr;
+
+        use tracing::{error, info};
+
+        unsafe {
+            if let Some(errorbuf) = crate::ffi::cdda_errors(self.as_ptr()).as_mut() {
+                CStr::from_ptr(errorbuf)
+                    .to_string_lossy()
+                    .lines()
+                    .for_each(|line| error!("{line}"));
+
+                #[cfg(feature = "libcdio-paranoia")]
+                crate::ffi::cdio_cddap_free_messages(errorbuf);
+                #[cfg(not(feature = "libcdio-paranoia"))]
+                crate::ffi::libc::free(errorbuf as *mut std::ffi::c_char as *mut std::ffi::c_void);
+            }
+            if let Some(messagebuf) = crate::ffi::cdda_messages(self.as_ptr()).as_mut() {
+                CStr::from_ptr(messagebuf)
+                    .to_string_lossy()
+                    .lines()
+                    .for_each(|line| info!("{line}"));
+
+                #[cfg(feature = "libcdio-paranoia")]
+                crate::ffi::cdio_cddap_free_messages(messagebuf);
+                #[cfg(not(feature = "libcdio-paranoia"))]
+                crate::ffi::libc::free(
+                    messagebuf as *mut std::ffi::c_char as *mut std::ffi::c_void,
+                );
+            }
+        }
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -19,6 +19,9 @@ impl<'drive> Drop for Paranoia<'drive> {
 impl<'drive> Paranoia<'drive> {
     pub(crate) fn new(drive: &'drive Drive) -> Self {
         let ptr = unsafe { crate::ffi::paranoia_init(drive.as_ptr()) };
+
+        drive.check_messages();
+
         assert!(!ptr.is_null(), "paranoia_init should be infallible");
         Self { ptr, drive }
     }
@@ -114,6 +117,9 @@ impl<'drive, 'paranoia> DiscReader<'drive, 'paranoia> {
         let data = unsafe {
             let ptr =
                 crate::ffi::paranoia_read_limited(self.paranoia.as_ptr(), None, self.max_retries);
+
+            self.paranoia.drive.check_messages();
+
             if ptr.is_null() {
                 return Some(Err(Error::Read));
             }


### PR DESCRIPTION
CC @agausmann

Adds a `tracing` feature. When enabled, `CDDA_MESSAGE_LOGIT` is used and after each call to cdparanoia it is checked if there are new (error) messages which get logged using the [`tracing`](https://docs.rs/tracing) crate.

